### PR TITLE
Add 0.5.2 on arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ test:
     - patsy
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
Build patsy 0.5.2 on arm64 again because artefacts weren't uploaded on defaults due to the issues on CI/CD