### PR TITLE
Add patsy 0.5.2 on osx-arm64 for py38 and python 3.10 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy >=1.4.0
     - six
     # Optional: scipy needed for spline-related functions like bs 
-    - scipy
+    #- scipy
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,14 @@ requirements:
     # need at least numpy 1.4 for triu_indices
     - numpy >=1.4.0
     - six
-    # Optional: scipy needed for spline-related functions like bs 
-    #- scipy
 
 test:
   imports:
     - patsy
   requires:
     - pip
+    # Optional: scipy needed for spline-related functions like bs 
+    #- scipy
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,18 +11,18 @@ source:
   sha256: 5053de7804676aba62783dbb0f23a2b3d74e35e5bfa238b88b7cbf148a38b69d
 
 build:
-  number: 0
+  number: 1
   script:
     - python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   host:
-    - python <3.10
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python <3.10
+    - python
     # need at least numpy 1.4 for triu_indices
     - numpy >=1.4.0
     - six
@@ -34,7 +34,6 @@ test:
     - patsy
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
patsy 0.5.2 on `osx-arm64` for `py38` and python 3.10 support for other platforms. `statsmodels 0.13.0` requires it for py38.

1. Bump build number to `1`, 
2. Fix python: add `python 3.10` support on all platforms
3. Disable `scipy` as it's an optional dependency only for testing purposes https://github.com/pydata/patsy/blob/fb0125ebc74a31cbbaeaf95e2e066765c30b9ee8/setup.py#L31 (it causes an `Unsatisfiable dependencies` error on `ppc64le` for `py310` and on `win32` for `py310`)