### PR TITLE
patsy 0.5.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.3" %}
+{% set version = "0.5.6" %}
 {% set pkg_name = "patsy" %}
 
 
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ pkg_name[0] }}/{{ pkg_name }}/{{ pkg_name }}-{{ version }}.tar.gz
-  sha256: bdc18001875e319bc91c812c1eb6a10be4bb13cb81eb763f466179dca3b67277
+  sha256: 95c6d47a7222535f84bff7f63d7303f2e297747a598db89cf5c67f0c0c7d2cdb
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script:
-    - {{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
 
 requirements:
   host:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository](https://github.com/pydata/patsy/tree/v0.5.6)
- [Upstream changelog/diff](https://github.com/pydata/patsy/releases)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/statsmodels-feedstock/pull/8

### Explanation of changes:

- Set version and sha256
